### PR TITLE
Fix: call rotate before resizing (before EXIF meta data is lost)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -136,7 +136,7 @@ async function getStreamableImage(
       downscaleFactorBytesEstimated
     );
 
-    streamable = streamable.resize(Math.round(imageMeta.width * factor));
+    streamable = streamable.rotate().resize(Math.round(imageMeta.width * factor));
   }
 
   if (options.sharpen) {


### PR DESCRIPTION
Some jpg images have EXIF orientation data attached to them to determine if they have to be rotated. After calling resize in sharp this information is lost and the image appears to be rotated compared to the original. To avoid this I added `rotate` before calling the `resize` function. Alternatively one could also use `.withMetadata()` after the `resize` function to keep the EXIF data.

Further reading and solution:
https://stackoverflow.com/questions/48716266/sharp-image-library-rotates-image-when-resizing